### PR TITLE
取消作者人数上限，改为手动使用 others 添加 et al.

### DIFF
--- a/gbt7714-2005.bst
+++ b/gbt7714-2005.bst
@@ -614,9 +614,6 @@ FUNCTION {format.names} {                         % String Entry::format_names(S
   #0 'nameindex :=                                %   nameindex = 0;
   {nameindex namecount < nameindex #3 < and} {    %   while ((nameindex < namecount) && (nameindex < 3)) {
     nameindex #1 + 'nameindex :=                  %     nameindex = nameindex + 1;
-    nameindex #1 > {                              %     if (nameindex > 1) {
-      cap.comma *                                 %       result = result + cap_comma;
-    } 'skip$ if$                                  %     }
     namelist nameindex "{vv}" format.name$        %     String tmp = format_name(namelist, nameindex, "{vv}");
    'vonname :=                                    %     vonname = tmp;
     namelist nameindex "{jj}" format.name$        %     tmp = format_name(namelist, nameindex, "{jj}");
@@ -626,19 +623,26 @@ FUNCTION {format.names} {                         % String Entry::format_names(S
     "u" change.case$ 'firstname :=                %     firstname = change_case(tmp, "u");
     namelist nameindex "{ll}" format.name$        %     tmp = format_name(namelist, nameindex, "{ll}");
     "u" change.case$ 'lastname :=                 %     lastname = change_case(tmp, "u");
-    jrname empty$ not {                           %     if (! empty(jrname)) {
-      jrname * " " *                              %       result = result + jrname + " "
-    } 'skip$ if$                                  %     }
-    vonname empty$ not {                          %     if (! empty(vonname)) {
-      vonname * " " *                             %       result = result + vonname + " "
-    } 'skip$ if$                                  %     }
-    lastname empty$ not {                         %     if (! empty(lastname)) {
-      lastname * " " *                            %       result = result + lastname + " "
-    } 'skip$ if$                                  %     }
-    firstname empty$ not {                        %     if (! empty(firstname)) {
-      firstname * " " *                           %       result = result + firstname + " "
-    } 'skip$ if$                                  %     }
-    trim.end                                      %     result = trim_end(result);
+    lastname "OTHERS" = not {                     %     if (lastname != "OTHERS") {
+      nameindex #1 > {                            %       if (nameindex > 1) {
+        cap.comma *                               %         result = result + cap_comma;
+      } 'skip$ if$                                %       }
+      jrname empty$ not {                         %       if (! empty(jrname)) {
+        jrname * " " *                            %         result = result + jrname + " "
+      } 'skip$ if$                                %       }
+      vonname empty$ not {                        %       if (! empty(vonname)) {
+        vonname * " " *                           %         result = result + vonname + " "
+      } 'skip$ if$                                %       }
+      lastname empty$ not {                       %       if (! empty(lastname)) {
+          lastname * " " *                        %         result = result + lastname + " "
+      } 'skip$ if$                                %       }
+      firstname empty$ not {                      %       if (! empty(firstname)) {
+          firstname * " " *                       %         result = result + firstname + " "
+      } 'skip$ if$                                %       }
+      trim.end                                    %       result = trim_end(result);
+    } {                                           %     }else {
+      cap.et.al *                                 %       result = result + cap_et_al();
+    } if$                                         %     }
   } while$                                        %   }
   nameindex namecount < {                         %   if (nameindex < namecount) {
     cap.et.al *                                   %     result = result + cap_et_al();

--- a/gbt7714-2005.bst
+++ b/gbt7714-2005.bst
@@ -612,7 +612,7 @@ FUNCTION {format.names} {                         % String Entry::format_names(S
   namelist num.names$ 'namecount :=               %   namecount = num_names(namelist);
   ""                                              %   String result = "";
   #0 'nameindex :=                                %   nameindex = 0;
-  {nameindex namecount < nameindex #3 < and} {    %   while ((nameindex < namecount) && (nameindex < 3)) {
+  {nameindex namecount <} {                       %   while (nameindex < namecount) {
     nameindex #1 + 'nameindex :=                  %     nameindex = nameindex + 1;
     namelist nameindex "{vv}" format.name$        %     String tmp = format_name(namelist, nameindex, "{vv}");
    'vonname :=                                    %     vonname = tmp;
@@ -644,9 +644,6 @@ FUNCTION {format.names} {                         % String Entry::format_names(S
       cap.et.al *                                 %       result = result + cap_et_al();
     } if$                                         %     }
   } while$                                        %   }
-  nameindex namecount < {                         %   if (nameindex < namecount) {
-    cap.et.al *                                   %     result = result + cap_et_al();
-  } 'skip$ if$                                    %   }
 }                                                 % }
                                                   %
                                                   %


### PR DESCRIPTION
在 issue #22 中提到，当前版本的 .bst 文件中，将最大作者人数固定为 3 人，超过三人的部分使用 `et al.` 替换。由于有时我们希望能在作者不足三人时直接使用 `et al.`，因此提出本 PR：

- 取消了最大作者人数 3 人的限制；
- 当需要使用 `et al.` 时，通过在作者列表中加入 `and others` 以在最终生成文档中加入一个 `et al.`；